### PR TITLE
Test item::charges_per_volume

### DIFF
--- a/src/units.h
+++ b/src/units.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <cstddef>
 #include <limits>
+#include <ostream>
 
 namespace units
 {
@@ -343,6 +344,25 @@ inline constexpr value_type to_gram( const quantity<value_type, mass_in_gram_tag
 inline constexpr double to_kilogram( const mass &v )
 {
     return v.value() / 1000.0;
+}
+
+// Streaming operators for debugging and tests
+// (for UI output other functions should be used which render in the user's
+// chosen units)
+inline std::ostream &operator<<( std::ostream &o, mass_in_gram_tag )
+{
+    return o << "g";
+}
+
+inline std::ostream &operator<<( std::ostream &o, volume_in_milliliter_tag )
+{
+    return o << "ml";
+}
+
+template<typename value_type, typename tag_type>
+inline std::ostream &operator<<( std::ostream &o, const quantity<value_type, tag_type> &v )
+{
+    return o << v.value() << tag_type{};
 }
 
 } // namespace units

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -1,0 +1,21 @@
+#include "catch/catch.hpp"
+
+#include "item.h"
+#include "units.h"
+
+TEST_CASE( "item_volume", "[item]" )
+{
+    item i( "battery", 0, item::default_charges_tag() );
+    // Would be better with Catch2 generators
+    units::volume big_volume = units::from_milliliter( std::numeric_limits<int>::max() / 2 );
+    for( units::volume v : {
+             0_ml, 1_ml, i.volume(), big_volume
+         } ) {
+        INFO( "checking batteries that fit in " << v );
+        auto charges_that_should_fit = i.charges_per_volume( v );
+        i.charges = charges_that_should_fit;
+        CHECK( i.volume() <= v );
+        i.charges++;
+        CHECK( i.volume() > v );
+    }
+}


### PR DESCRIPTION
Test for recent regression on large containers.

Involves adding streaming operators for quantities so that Catch can print them out.
